### PR TITLE
feat: add E2E Dockerfile

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,38 @@
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-alpine3.17 as builder
+
+RUN apk add --no-cache git gcc make libc-dev linux-headers
+RUN set -eux; apk add --no-cache ca-certificates build-base
+
+# See https://github.com/CosmWasm/wasmvm/releases
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.aarch64.a /lib/libwasmvm_muslc.aarch64.a
+ADD https://github.com/CosmWasm/wasmvm/releases/download/v1.1.1/libwasmvm_muslc.x86_64.a /lib/libwasmvm_muslc.x86_64.a
+RUN sha256sum /lib/libwasmvm_muslc.aarch64.a | grep 9ecb037336bd56076573dc18c26631a9d2099a7f2b40dc04b6cae31ffb4c8f9a
+RUN sha256sum /lib/libwasmvm_muslc.x86_64.a | grep 6e4de7ba9bad4ae9679c7f9ecf7e283dd0160e71567c6a7be6ae47c81ebe7f32
+
+# Copy the library you want to the final location that will be found by the linker flag `-lwasmvm_muslc`
+RUN cp /lib/libwasmvm_muslc.$(uname -m).a /lib/libwasmvm_muslc.a
+
+WORKDIR /src
+COPY go.mod .
+COPY go.sum .
+RUN --mount=type=cache,target=/go/pkg/mod go mod download
+
+COPY . .
+
+ARG BIN_NAME
+ARG BIN_PACKAGE
+
+RUN --mount=type=cache,target=/go/pkg/mod --mount=type=cache,target=/root/.cache/go-build go build -tags=muslc -ldflags="-extldflags=-static" -trimpath -o /out/${BIN_NAME} ${BIN_PACKAGE}
+
+FROM alpine:3.17
+
+ARG BIN_NAME
+COPY --from=builder /out/${BIN_NAME} /usr/bin/${BIN_NAME}
+
+VOLUME /mnt
+WORKDIR /mnt
+
+ENV BIN_NAME ${BIN_NAME}
+
+CMD /usr/bin/${BIN_NAME} "price-feeder.toml"

--- a/Makefile
+++ b/Makefile
@@ -81,3 +81,14 @@ lint: ## golangci-lint
 define print-target
     @printf "Executing target: \033[36m$@\033[0m\n"
 endef
+
+.PHONY: image
+image-e2e: export DOCKER_BUILDKIT=1
+image-e2e: export BUILDKIT_INLINE_CACHE=1
+image-e2e:
+	docker build --ssh=default \
+		--build-arg GO_VERSION="1.20" \
+		--build-arg BIN_NAME="oracle-feeder" \
+		--build-arg BIN_PACKAGE="github.com/persistenceOne/oracle-feeder" \
+		--tag "persistenceone/oracle-feeder-e2e" \
+		-f Dockerfile.e2e .


### PR DESCRIPTION
Added a Dockerfile and Makefile command to build an image used for E2E tests.

How to build an image:

```
make image-e2e
```

How to use it:
```
docker run --rm -it persistenceone/oracle-feeder-e2e
```

Note: the dockerfile is not specific to E2E case, the image can be used as a reference for a normal image, if someone wants to run the oracle in the Docker later.
