### PR TITLE
chore: remove unused field in struct

### DIFF
--- a/oracle/client/client.go
+++ b/oracle/client/client.go
@@ -42,7 +42,6 @@ type (
 		RPCTimeout          time.Duration
 		OracleAddr          sdk.AccAddress
 		OracleAddrString    string
-		ValidatorAddr       sdk.ValAddress
 		ValidatorAddrString string
 		Encoding            simparams.EncodingConfig
 		GasPrices           string
@@ -89,7 +88,6 @@ func NewOracleClient(
 		RPCTimeout:          rpcTimeout,
 		OracleAddr:          oracleAddr,
 		OracleAddrString:    oracleAddrString,
-		ValidatorAddr:       sdk.ValAddress(validatorAddrString),
 		ValidatorAddrString: validatorAddrString,
 		Encoding:            simapp.MakeTestEncodingConfig(),
 		GasAdjustment:       gasAdjustment,


### PR DESCRIPTION
Removed unused field.

Moreover, the conversion `sdk.ValAddress(validatorAddrString)` was incorrect.